### PR TITLE
Remove DoubleColumn because it is not working correctly

### DIFF
--- a/Sources/SettingsHelper/SettingsView.swift
+++ b/Sources/SettingsHelper/SettingsView.swift
@@ -98,7 +98,6 @@ public struct SettingsView<TopFormContent: View, BottomFormContent: View>: View 
 
             DetailNothingSelectedView()
         }
-        .navigationViewStyle(DoubleColumnNavigationViewStyle())
     }
 }
 


### PR DESCRIPTION
On iPad 11 inch the DetailView is presented by default which cannot be changed as of right now.